### PR TITLE
fix: Switch nc timeout flag to -G

### DIFF
--- a/script/caspercheck.sh
+++ b/script/caspercheck.sh
@@ -184,7 +184,7 @@ CheckTomcat (){
 # Verifies that the JSS's Tomcat service is responding via its assigned port.
 
 
-tomcat_chk=`nc -z -w 5 $jss_server_address $jss_server_port > /dev/null; echo $?`
+tomcat_chk=`nc -z -G 5 $jss_server_address $jss_server_port > /dev/null; echo $?`
 
 if [ "$tomcat_chk" -eq 0 ]; then
        ScriptLogging "Machine can connect to $jss_server_address over port $jss_server_port. Proceeding."


### PR DESCRIPTION
The -G flag is for timeout on TCP connections while the old timeout flag, -w, is for when connection and stdin are idle which doesn't work as intended.

A sample can be verified with:

```bash
# Correct error + timeout
nc -z -G 5 google.com 8443
echo $?
1

# Correct check - IE - no change from current
nc -z -G 5 google.com 443
Connection to google.com port 443 [tcp/https] succeeded!

# Past behavior. The 'nc' binary will continue to wait forever
nc -z -w 5 google.com 8443
^C⏎       
```